### PR TITLE
Fixed JSON file reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -554,10 +554,10 @@
             }
         }
 
-        // Load models from current.json
+        // Load models from current-v1.json
         async function loadModels() {
             try {
-                const response = await fetch('current.json');
+                const response = await fetch('current-v1.json');
                 const data = await response.json();
 
                 // Convert prices array to object with id as the key


### PR DESCRIPTION
The https://www.llm-prices.com website seems to be a bit borked at the moment, as it's referencing `current.json` for the model data, but it looks like it should actually be `current-v1.json` - this PR fixes that.

Thanks for this tool BTW!