### PR TITLE
Add price multipliers when comparing multiple models

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,11 +445,11 @@
 
                         let multiplierParts = [];
                         if (inputCost > minInputPrice) {
-                            multiplierParts.push(`${inputMultiplier.toFixed(2)}x input vs ${minInputModel.name}`);
+                            multiplierParts.push(`${trimZeros(inputMultiplier.toFixed(2))}x input vs ${minInputModel.name}`);
                         }
                         if (outputCost > minOutputPrice) {
                             const outputRef = minOutputModel.key === minInputModel.key ? '' : ` vs ${minOutputModel.name}`;
-                            multiplierParts.push(`${outputMultiplier.toFixed(2)}x output${outputRef}`);
+                            multiplierParts.push(`${trimZeros(outputMultiplier.toFixed(2))}x output${outputRef}`);
                         }
 
                         if (multiplierParts.length > 0) {


### PR DESCRIPTION
When 2+ models are selected for comparison, show multiplier text on more
expensive models indicating how their input/output prices compare to the
cheapest selected model (e.g., "2.50x input vs GPT-4o Mini, 1.67x output").

----

> Make it so when two or more models have been selected the more expensive models include a bit of text that shows the multiple of their input price over the cheapest models in the set, and the multiple of their output too
Eg “1.5x input price for GPT 5 Nano, 0.85x output price”