### PR TITLE
Format currency display: trim trailing zeros, hide cents for values >= $1

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,8 +209,7 @@
                     <input type="number" id="outputCost" min="0" step="0.000001">
                 </div>
                 <div class="result">
-                    <p>Total cost: $<span id="costDollars">0.000000</span></p>
-                    <p>Total cost: <span id="costCents">0</span> cents</p>
+                    <p>Total cost: <span id="costFormatted">$0 (0 cents)</span></p>
                 </div>
                 <div id="multiModelResults" style="display: none; margin-top: 20px;">
                     <!-- Multi-model comparison results will appear here -->
@@ -294,8 +293,7 @@
             inputCost: 'inputCost',
             cachedInputCost: 'cachedInputCost',
             outputCost: 'outputCost',
-            costDollars: 'costDollars',
-            costCents: 'costCents',
+            costFormatted: 'costFormatted',
             presetTableBody: 'presetTableBody',
             sortByName: 'sortByName',
             sortByInput: 'sortByInput',
@@ -460,7 +458,7 @@
                     }
 
                     html += `<div style="font-size: 18px; color: #2ecc71; font-weight: bold;">`;
-                    html += `$${totalCost.toFixed(6)} (${trimZeros((totalCost * 100).toFixed(4))} cents)`;
+                    html += formatCost(totalCost);
                     html += `</div>`;
                     html += `</div>`;
                 });
@@ -475,14 +473,23 @@
 
                 const totalCost = (inputTokens * inputCost / 1000000) + (cachedInputTokens * cachedInputCost / 1000000) + (outputTokens * outputCost / 1000000);
 
-                document.getElementById(elIds.costDollars).textContent = totalCost.toFixed(6);
-                document.getElementById(elIds.costCents).textContent = trimZeros((totalCost * 100).toFixed(4));
+                document.getElementById(elIds.costFormatted).textContent = formatCost(totalCost);
             }
             updateUrlHash();
         }
 
         function trimZeros(numStr) {
             return numStr.replace(/\.?0+$/, '');
+        }
+
+        function formatCost(totalCost) {
+            const dollars = trimZeros(totalCost.toFixed(6));
+            if (totalCost >= 1) {
+                return `$${dollars}`;
+            } else {
+                const cents = trimZeros((totalCost * 100).toFixed(4));
+                return `$${dollars} (${cents} cents)`;
+            }
         }
 
         function setPreset(modelKey) {


### PR DESCRIPTION
- Add formatCost() function that trims trailing zeros and only shows
  cents in parentheses when value is less than $1
- Consolidate two-line cost display into single formatted line
- Apply formatting to both single-model and multi-model comparison views

----

> 
> GPT-5 Nano
> Input: $0.05/M (Cached: $0.005/M) | Output: $0.40/M
> $0.450000 (45 cents)
> GPT-3 Text Davinci 003
> Input: $20/M | Output: $20/M
> 400x input vs GPT-5 Nano, 50x output
> $40.000000 (4000 cents)
>
> That would show $0.45 (45 cents) and $40
> So not all those trailing 0000 and if a value is more than $1 it doesn’t show the number of cents, just the number of dollars