### PR TITLE
Fix price formatting for display of model total cost

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,13 +495,15 @@
         }
 
         function formatCost(totalCost) {
-            const dollars = trimZeros(totalCost.toFixed(6));
-            if (totalCost >= 1) {
-                return `$${dollars}`;
-            } else {
-                const cents = trimZeros((totalCost * 100).toFixed(4));
-                return `$${dollars} (${cents} cents)`;
+            // Show whole dollar amounts without decimals (e.g. $60)
+            // and amounts with cents with two decimal places (e.g. $3.20, $0.05).
+            if (!isFinite(totalCost) || isNaN(totalCost)) return '$0';
+            const rounded = Math.round(totalCost);
+            // Treat values very close to integers as integers to avoid floating point noise
+            if (Math.abs(totalCost - rounded) < 1e-9) {
+                return `$${rounded}`;
             }
+            return `$${totalCost.toFixed(2)}`;
         }
 
         function setPreset(modelKey) {


### PR DESCRIPTION
Fix display of model total cost to show whole dollar value or with two decimal place cent value.

Currently, if calculated model cost is:

- a whole dollar value, it is showed without decimals, e.g. `$60`
- a decimal cent value with non-zero penny value, it is showed as two decimal places, e.g. `$3.25`
- a decimal cent value with zero penny value, it is showed incorrectly as one decimal place, e.g. `$6.7`

This fix correctly displays values either as whole dollars or with two decimal places.

<img width="358" height="455" alt="image" src="https://github.com/user-attachments/assets/a5ee1d73-b246-4a16-ab3e-63622c33ae24" />