### PR TITLE
Add Kimi K2.6 pricing

### DIFF
--- a/data/moonshot-ai.json
+++ b/data/moonshot-ai.json
@@ -2,6 +2,19 @@
   "vendor": "moonshot-ai",
   "models": [
     {
+      "id": "kimi-k2.6",
+      "name": "Kimi K2.6",
+      "price_history": [
+        {
+          "input": 0.95,
+          "output": 4.0,
+          "from_date": null,
+          "to_date": null,
+          "input_cached": 0.16
+        }
+      ]
+    },
+    {
       "id": "kimi-k2-0905-preview",
       "name": "Kimi K2 0905 Preview",
       "price_history": [


### PR DESCRIPTION
Source: https://platform.kimi.ai/docs/pricing/chat-k26

- Input: $0.95 / 1M tokens
- Cached input: $0.16 / 1M tokens
- Output: $4.00 / 1M tokens

(Disclosure: AI was used; however I am fully responsible for changes.)