### PR TITLE
Update Mistral pricing: Mistral 3 family + new models (checked by a human)

### DIFF
--- a/data/mistral.json
+++ b/data/mistral.json
@@ -16,7 +16,7 @@
     },
     {
       "id": "mistral-small-latest",
-      "name": "Mistral Small 3.1",
+      "name": "Mistral Small 4",
       "price_history": [
         {
           "input": 0.1,
@@ -34,6 +34,19 @@
         {
           "input": 0.4,
           "output": 2,
+          "from_date": null,
+          "to_date": null,
+          "input_cached": null
+        }
+      ]
+    },
+    {
+      "id": "mistral-medium-latest",
+      "name": "Mistral Medium 3.5",
+      "price_history": [
+        {
+          "input": 1.5,
+          "output": 7.5,
           "from_date": null,
           "to_date": null,
           "input_cached": null
@@ -94,13 +107,20 @@
     },
     {
       "id": "mistral-large-latest",
-      "name": "Mistral Large 24.11",
+      "name": "Mistral Large 3",
       "price_history": [
+        {
+          "input": 0.5,
+          "output": 1.5,
+          "from_date": "2025-12-02",
+          "to_date": null,
+          "input_cached": null
+        },
         {
           "input": 2,
           "output": 6,
           "from_date": null,
-          "to_date": null,
+          "to_date": "2025-12-02",
           "input_cached": null
         }
       ]
@@ -146,24 +166,51 @@
     },
     {
       "id": "ministral-8b-latest",
-      "name": "Ministral 8B 24.10",
+      "name": "Ministral 3 - 8B",
       "price_history": [
+        {
+          "input": 0.15,
+          "output": 0.15,
+          "from_date": "2025-12-02",
+          "to_date": null,
+          "input_cached": null
+        },
         {
           "input": 0.1,
           "output": 0.1,
           "from_date": null,
-          "to_date": null,
+          "to_date": "2025-12-02",
           "input_cached": null
         }
       ]
     },
     {
       "id": "ministral-3b-latest",
-      "name": "Ministral 3B 24.10",
+      "name": "Ministral 3 - 3B",
       "price_history": [
+        {
+          "input": 0.1,
+          "output": 0.1,
+          "from_date": "2025-12-02",
+          "to_date": null,
+          "input_cached": null
+        },
         {
           "input": 0.04,
           "output": 0.04,
+          "from_date": null,
+          "to_date": "2025-12-02",
+          "input_cached": null
+        }
+      ]
+    },
+    {
+      "id": "ministral-14b-latest",
+      "name": "Ministral 3 - 14B",
+      "price_history": [
+        {
+          "input": 0.2,
+          "output": 0.2,
           "from_date": null,
           "to_date": null,
           "input_cached": null
@@ -177,6 +224,45 @@
         {
           "input": 2,
           "output": 5,
+          "from_date": null,
+          "to_date": null,
+          "input_cached": null
+        }
+      ]
+    },
+    {
+      "id": "magistral-small-latest",
+      "name": "Magistral Small",
+      "price_history": [
+        {
+          "input": 0.5,
+          "output": 1.5,
+          "from_date": null,
+          "to_date": null,
+          "input_cached": null
+        }
+      ]
+    },
+    {
+      "id": "devstral-medium-latest",
+      "name": "Devstral 2",
+      "price_history": [
+        {
+          "input": 0.4,
+          "output": 2,
+          "from_date": null,
+          "to_date": null,
+          "input_cached": null
+        }
+      ]
+    },
+    {
+      "id": "devstral-small-latest",
+      "name": "Devstral Small 2",
+      "price_history": [
+        {
+          "input": 0.1,
+          "output": 0.3,
           "from_date": null,
           "to_date": null,
           "input_cached": null


### PR DESCRIPTION
Source: https://mistral.ai/pricing/#api

Updates data/mistral.json against https://mistral.ai/pricing/#api.
The *-latest aliases moved to new models on 2025-12-02 (the Mistral 3 launch), recorded as price_history transitions:

mistral-large-latest: 2/6 → 0.5/1.5 (Mistral Large 24.11 → Mistral Large 3)
ministral-8b-latest: 0.1/0.1 → 0.15/0.15 (→ Ministral 3 - 8B)
ministral-3b-latest: 0.04/0.04 → 0.1/0.1 (→ Ministral 3 - 3B)

Name update only (price unchanged): mistral-small-latest Mistral Small 3.1 → Mistral Small 4.
New models: Mistral Medium 3.5 (1.5/7.5), Ministral 3 - 14B (0.2/0.2), Magistral Small (0.5/1.5), Devstral 2 (0.4/2), Devstral Small 2 (0.1/0.3).
