### PR TITLE
Add gemini 3.6 flash and gemini 3.5 flash lite

### DIFF
--- a/data/google.json
+++ b/data/google.json
@@ -286,6 +286,32 @@
           "input_cached": 0.15
         }
       ]
+    },
+    {
+      "id": "gemini-3.5-flash-lite",
+      "name": "Gemini 3.5 Flash-Lite",
+      "price_history": [
+        {
+          "input": 0.30,
+          "output": 2.50,
+          "from_date": null,
+          "to_date": null,
+          "input_cached": 0.03
+        }
+      ]
+    },
+    {
+      "id": "gemini-3.6-flash",
+      "name": "Gemini 3.6 Flash",
+      "price_history": [
+        {
+          "input": 1.50,
+          "output": 7.50,
+          "from_date": null,
+          "to_date": null,
+          "input_cached": 0.15
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added prices for Gemini 3.6 flash and Gemini 3.5 Flash lite.

https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
https://ai.google.dev/gemini-api/docs/pricing#gemini-3.5-flash-lite